### PR TITLE
Moved dependency on NUnit test adapter to the test project

### DIFF
--- a/Rebus.RabbitMq.Tests/Rebus.RabbitMq.Tests.csproj
+++ b/Rebus.RabbitMq.Tests/Rebus.RabbitMq.Tests.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Rebus.RabbitMq\Rebus.RabbitMq.csproj" />
     <PackageReference Include="nunit" Version="3.7.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
     <PackageReference Include="rabbitmq.client" Version="4.1.1" />
     <PackageReference Include="rebus" Version="4.0.1" />
     <PackageReference Include="rebus.tests.contracts" Version="4.0.0" />

--- a/Rebus.RabbitMq/Rebus.RabbitMq.csproj
+++ b/Rebus.RabbitMq/Rebus.RabbitMq.csproj
@@ -46,7 +46,6 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
     <PackageReference Include="rebus" Version="4.0.1" />
     <PackageReference Include="RabbitMq.Client" Version="4.1.1" />
   </ItemGroup>


### PR DESCRIPTION
so it does not end up as a NuGet package dependency for Rebus.RabbitMq

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
