### PR TITLE
Test case exposing issue with mandatory delivery handler required on …

### DIFF
--- a/Rebus.RabbitMq.Tests/RabbitMqMandatoryDeliveryTest.cs
+++ b/Rebus.RabbitMq.Tests/RabbitMqMandatoryDeliveryTest.cs
@@ -1,13 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using RabbitMQ.Client;
 using Rebus.Activation;
 using Rebus.Bus;
 using Rebus.Config;
 using Rebus.Exceptions;
 using Rebus.Logging;
+using Rebus.Retry.Simple;
 using Rebus.Tests.Contracts;
 using Rebus.Tests.Contracts.Extensions;
 
@@ -17,10 +20,12 @@ namespace Rebus.RabbitMq.Tests
     public class RabbitMqMandatoryDeliveryTest : FixtureBase
     {
         readonly string _noneExistingQueueName = TestConfig.GetName("non-existing-queue");
+        readonly string _mandatoryQueue = TestConfig.GetName("mandatory-queue");
 
         protected override void SetUp()
         {
             RabbitMqTransportFactory.DeleteQueue(_noneExistingQueueName);
+            RabbitMqTransportFactory.DeleteQueue(_mandatoryQueue);
         }
 
         [Test]
@@ -62,6 +67,52 @@ namespace Rebus.RabbitMq.Tests
             gotCallback.WaitOrDie(TimeSpan.FromSeconds(2));
         }
 
+        /// <summary>
+        /// Exposes a potential problem with the mandatory delivery method: 
+        /// When the mandatory header is used and an exception is thrown in the handler. 
+        /// Then the delivery to the error queue throws a MandatoryDeliveryException because a handler for BasicReturn is not configured on the server
+        /// 
+        /// sender -> mandatory message -> server
+        /// server -> handler throws exception
+        /// rebus -> transfer to error queue
+        /// rabbit transport -> throws MandatoryDeliveryException since server does not have th required handler
+        /// </summary>
+        /// <returns></returns>
+        [Test, Ignore("Exposes an issue with the mandatory delivery")]
+        public async Task CanTransferMandatoryHeaderToErrorQueue()
+        {
+            var recievedMessageOnErrorQueue = new ManualResetEvent(false);
+
+            var inputQueueServer = StartServer(_mandatoryQueue).Handle<string>(str =>
+            {
+                Console.WriteLine($"Message arrived on queue: {_mandatoryQueue}: {str}");
+
+                throw new Exception("Exception in handler");
+            });
+
+            Using(inputQueueServer);
+
+            var errorQueueServer = StartServer("error").Handle<string>(str =>
+            {
+                Console.WriteLine($"Message arrived on queue: error: {str}");
+
+                recievedMessageOnErrorQueue.Set();
+
+                return Task.FromResult(0);
+            });
+
+            Using(errorQueueServer);
+
+            var bus = StartOneWayClient((sender, eventArgs) => { /* Required eventhandler for mandatory delivery */ });
+
+            await bus.Advanced.Routing.Send(_mandatoryQueue, "I'm mandatory and throws exception", new Dictionary<string, string>
+            {
+                [RabbitMqHeaders.Mandatory] = bool.TrueString,
+            });
+
+            recievedMessageOnErrorQueue.WaitOrDie(TimeSpan.FromSeconds(5));
+        }
+
         IBus StartOneWayClient(Action<object, BasicReturnEventArgs> basicReturnCallback)
         {
             var client = Using(new BuiltinHandlerActivator());
@@ -71,6 +122,19 @@ namespace Rebus.RabbitMq.Tests
                 .Transport(t => t.UseRabbitMqAsOneWayClient(RabbitMqTransportFactory.ConnectionString)
                     .Mandatory(basicReturnCallback))
                 .Start();
+        }
+
+        BuiltinHandlerActivator StartServer(string queueName)
+        {
+            var activator = Using(new BuiltinHandlerActivator());
+
+            Configure.With(activator)
+                .Logging(l => l.Console(minLevel: LogLevel.Warn))
+                .Transport(t => t.UseRabbitMq(RabbitMqTransportFactory.ConnectionString, queueName))
+                .Options(o => o.SimpleRetryStrategy(maxDeliveryAttempts:1))
+                .Start();
+
+            return activator;
         }
     }
 }


### PR DESCRIPTION
…server on tranfer to error queue

When the mandatory header is used and an exception is thrown in the handler. 
Then the delivery to the error queue throws a MandatoryDeliveryException because a handler for BasicReturn is not configured on the server

sender -> mandatory message -> server
server -> handler throws exception
rebus -> transfer to error queue
rabbit transport -> throws MandatoryDeliveryException since server does not have th required handler

I think this is a problem. Transfers to error queues should not be dependant on the mandatory delivery handler being configured. However I don't know how to check whether the destinationAddress in SendOutgoingMessages() is to an error queue?

The problem can be bypassed by configuring an empty handler on the server as welll.

Any suggestions?
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
