### PR TITLE
Update dependencies, specifically RabbitMq.Client

### DIFF
--- a/Rebus.RabbitMq.Tests/RabbitMqPriorityQueueTest.cs
+++ b/Rebus.RabbitMq.Tests/RabbitMqPriorityQueueTest.cs
@@ -36,7 +36,7 @@ namespace Rebus.RabbitMq.Tests
             // Check if queues exists
             Assert.DoesNotThrow(() =>
             {
-                var connectionFactory = new ConnectionFactory { Uri = RabbitMqTransportFactory.ConnectionString };
+                var connectionFactory = new ConnectionFactory { Uri = new Uri(RabbitMqTransportFactory.ConnectionString) };
 
                 using (var connection = connectionFactory.CreateConnection())
                 using (var model = connection.CreateModel())
@@ -62,7 +62,7 @@ namespace Rebus.RabbitMq.Tests
 
             Assert.Throws<OperationInterruptedException>(() =>
             {
-                var connectionFactory = new ConnectionFactory { Uri = RabbitMqTransportFactory.ConnectionString };
+                var connectionFactory = new ConnectionFactory { Uri = new Uri(RabbitMqTransportFactory.ConnectionString) };
 
                 using (var connection = connectionFactory.CreateConnection())
                 using (var model = connection.CreateModel())

--- a/Rebus.RabbitMq.Tests/RabbitMqTransportFactory.cs
+++ b/Rebus.RabbitMq.Tests/RabbitMqTransportFactory.cs
@@ -52,7 +52,7 @@ namespace Rebus.RabbitMq.Tests
 
         public static void DeleteQueue(string queueName)
         {
-            var connectionFactory = new ConnectionFactory { Uri = ConnectionString };
+            var connectionFactory = new ConnectionFactory { Uri = new Uri(ConnectionString) };
 
             using (var connection = connectionFactory.CreateConnection())
             using (var model = connection.CreateModel())
@@ -63,7 +63,7 @@ namespace Rebus.RabbitMq.Tests
 
         public static void DeleteExchange(string exchangeName)
         {
-            var connectionFactory = new ConnectionFactory { Uri = ConnectionString };
+            var connectionFactory = new ConnectionFactory { Uri = new Uri(ConnectionString) };
 
             using (var connection = connectionFactory.CreateConnection())
             using (var model = connection.CreateModel())
@@ -79,7 +79,7 @@ namespace Rebus.RabbitMq.Tests
         /// </summary>
         public static bool ExchangeExists(string exchangeName)
         {
-            var connectionFactory = new ConnectionFactory { Uri = ConnectionString };
+            var connectionFactory = new ConnectionFactory { Uri = new Uri(ConnectionString) };
 
             using (var connection = connectionFactory.CreateConnection())
             using (var model = connection.CreateModel())

--- a/Rebus.RabbitMq.Tests/Rebus.RabbitMq.Tests.csproj
+++ b/Rebus.RabbitMq.Tests/Rebus.RabbitMq.Tests.csproj
@@ -36,9 +36,9 @@
     <ProjectReference Include="..\Rebus.RabbitMq\Rebus.RabbitMq.csproj" />
     <PackageReference Include="nunit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="rabbitmq.client" Version="4.1.1" />
-    <PackageReference Include="rebus" Version="4.0.1" />
-    <PackageReference Include="rebus.tests.contracts" Version="4.0.0" />
+    <PackageReference Include="rabbitmq.client" Version="5.0.1" />
+    <PackageReference Include="rebus" Version="4.2.1" />
+    <PackageReference Include="rebus.tests.contracts" Version="4.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Rebus.RabbitMq.Tests/ReceiveNonRebusMessageWithRabbitMq.cs
+++ b/Rebus.RabbitMq.Tests/ReceiveNonRebusMessageWithRabbitMq.cs
@@ -52,7 +52,7 @@ namespace Rebus.RabbitMq.Tests
                 receivedCustomStringMessage.Set();
             });
 
-            using (var connection = new ConnectionFactory { Uri = ConnectionString }.CreateConnection())
+            using (var connection = new ConnectionFactory { Uri = new Uri(ConnectionString) }.CreateConnection())
             {
                 using (var model = connection.CreateModel())
                 {

--- a/Rebus.RabbitMq/RabbitMq/ConnectionEndpoint.cs
+++ b/Rebus.RabbitMq/RabbitMq/ConnectionEndpoint.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Rebus.RabbitMq
 {
     /// <summary>
@@ -9,6 +11,11 @@ namespace Rebus.RabbitMq
         /// Will be mapped to RabbitMq URI
         /// </summary>
         public string ConnectionString { get; set; }
+
+        /// <summary>
+        /// Wraps <see cref="ConnectionString"/> in a <see cref="Uri"/>
+        /// </summary>
+        public Uri ConnectionUri => new Uri(ConnectionString);
 
         /// <summary>
         /// Will be mapped to RabbitMq SslOptions. Could be null

--- a/Rebus.RabbitMq/RabbitMq/ConnectionManager.cs
+++ b/Rebus.RabbitMq/RabbitMq/ConnectionManager.cs
@@ -56,7 +56,7 @@ namespace Rebus.RabbitMq
 
             _connectionFactory = new ConnectionFactory
             {
-                Uri = endpoints.First().ConnectionString, //Use the first URI in the list for ConnectionFactory to pick the AMQP credentials, VirtualHost (if any)
+                Uri = endpoints.First().ConnectionUri, //Use the first URI in the list for ConnectionFactory to pick the AMQP credentials, VirtualHost (if any)
                 AutomaticRecoveryEnabled = true,
                 NetworkRecoveryInterval = TimeSpan.FromSeconds(30),
                 ClientProperties = CreateClientProperties(inputQueueAddress)
@@ -106,7 +106,7 @@ namespace Rebus.RabbitMq
 
             _connectionFactory = new ConnectionFactory
             {
-                Uri = uriStrings.First(), //Use the first URI in the list for ConnectionFactory to pick the AMQP credentials (if any)
+                Uri = new Uri(uriStrings.First()), //Use the first URI in the list for ConnectionFactory to pick the AMQP credentials (if any)
                 AutomaticRecoveryEnabled = true,
                 NetworkRecoveryInterval = TimeSpan.FromSeconds(30),
                 ClientProperties = CreateClientProperties(inputQueueAddress)

--- a/Rebus.RabbitMq/Rebus.RabbitMq.csproj
+++ b/Rebus.RabbitMq/Rebus.RabbitMq.csproj
@@ -46,8 +46,8 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="rebus" Version="4.0.1" />
-    <PackageReference Include="RabbitMq.Client" Version="4.1.1" />
+    <PackageReference Include="rebus" Version="4.2.1" />
+    <PackageReference Include="RabbitMq.Client" Version="5.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />


### PR DESCRIPTION
As noted in #11 the breaking change in RabbitMq.Client v5.x is that Uri is no long a string but the actual System.Uri.  The changes to the code are to address that change only without breaking the Rebus API.  Let me know if you would like it handled differently.

NOTE: I did not update Nunit to latest because then VS can no longer see the tests.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
