### PR TITLE
Better performance on publisher confirms in transaction

### DIFF
--- a/Rebus.RabbitMq.Tests/RabbitMqPublisherConfirmsPublishPerformanceTest.cs
+++ b/Rebus.RabbitMq.Tests/RabbitMqPublisherConfirmsPublishPerformanceTest.cs
@@ -7,6 +7,7 @@ using Rebus.Activation;
 using Rebus.Config;
 using Rebus.Logging;
 using Rebus.Tests.Contracts;
+using Rebus.Transport;
 #pragma warning disable 1998
 
 namespace Rebus.RabbitMq.Tests
@@ -19,9 +20,14 @@ namespace Rebus.RabbitMq.Tests
         /// <summary>
         /// Without confirms: 15508.5 msg/s
         ///
-        /// With confirms
+        /// With confirms without transaction
         ///     - initial:                      645 msg/s
         ///     - move call to ConfirmSelect:   815.0 msg/s
+        /// 
+        /// (The following was done on a different machine, not directly comparable to other results)
+        /// With confirms and in transaction
+        ///     - initial                       118 msg/s
+        ///     - moved outside of send loop:   4315 msg/s 
         /// 
         /// </summary>
         [TestCase(true, 10000)]
@@ -44,23 +50,48 @@ namespace Rebus.RabbitMq.Tests
                     .EnablePublisherConfirms(value: enablePublisherConfirms))
                 .Start();
 
-            var stopwatch = Stopwatch.StartNew();
+            // In transaction
+            using(var scope = new RebusTransactionScope())
+            {
+                var stopwatch = Stopwatch.StartNew();
+
+                await Task.WhenAll(Enumerable.Range(0, count)
+                    .Select(n => $"THIS IS MESSAGE NUMBER {n} OUT OF {count}")
+                    .Select(str => activator.Bus.SendLocal(str)));
+
+                await scope.CompleteAsync();
+
+                var elapsedSeconds = stopwatch.Elapsed.TotalSeconds;
+
+                Console.WriteLine($@"Publishing 
+
+                    {count} 
+
+                messages in transaction with PUBLISHER CONFIRMS = {enablePublisherConfirms} took 
+
+                    {elapsedSeconds:0.0} s
+
+                - that's {count/elapsedSeconds:0.0} msg/s");
+             }
+
+            // Without transaction
+            var stopwatch2 = Stopwatch.StartNew();
 
             await Task.WhenAll(Enumerable.Range(0, count)
                 .Select(n => $"THIS IS MESSAGE NUMBER {n} OUT OF {count}")
                 .Select(str => activator.Bus.SendLocal(str)));
 
-            var elapsedSeconds = stopwatch.Elapsed.TotalSeconds;
+            var elapsedSeconds2 = stopwatch2.Elapsed.TotalSeconds;         
 
             Console.WriteLine($@"Publishing 
 
-    {count} 
+                {count} 
 
-messages with PUBLISHER CONFIRMS = {enablePublisherConfirms} took 
+            messages without transaction with PUBLISHER CONFIRMS = {enablePublisherConfirms} took 
 
-    {elapsedSeconds:0.0} s
+                {elapsedSeconds2:0.0} s
 
-- that's {count/elapsedSeconds:0.0} msg/s");
+            - that's {count/elapsedSeconds2:0.0} msg/s");
         }
     }
 }

--- a/Rebus.RabbitMq/RabbitMq/RabbitMqTransport.cs
+++ b/Rebus.RabbitMq/RabbitMq/RabbitMqTransport.cs
@@ -502,6 +502,11 @@ namespace Rebus.RabbitMq
         {
             var model = GetModel(context);
 
+            if (_publisherConfirmsEnabled)
+            {
+                model.ConfirmSelect();
+            }
+
             foreach (var outgoingMessage in outgoingMessages)
             {
                 var destinationAddress = outgoingMessage.DestinationAddress;
@@ -526,11 +531,6 @@ namespace Rebus.RabbitMq
                     EnsureQueueExists(routingKey, model);
                 }
 
-                if (_publisherConfirmsEnabled)
-                {
-                    model.ConfirmSelect();
-                }
-
                 model.BasicPublish(
                     exchange: exchange,
                     routingKey: routingKey.RoutingKey,
@@ -538,11 +538,11 @@ namespace Rebus.RabbitMq
                     basicProperties: props,
                     body: message.Body
                 );
+            }
 
-                if (_publisherConfirmsEnabled)
-                {
-                    model.WaitForConfirmsOrDie();
-                }
+            if (_publisherConfirmsEnabled)
+            {
+                model.WaitForConfirmsOrDie();
             }
         }
 


### PR DESCRIPTION
When sending multiple messages in a rebus transaction, it takes a lot of time to confirm each message individually. Since we are reusing the same IModel from the current transaction, it should be safe to confirm all messages in one go. The performance difference when running inside a rebus transaction is huge.

Batch confirms is also recommended from the RabbitMQ webside due to performance and latency.

I extended the current performance tests to also run in transaction to be able to compare side by side.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
