### PR TITLE
Fix AddArgument, Add Queue TTL config

### DIFF
--- a/Rebus.RabbitMq/Config/RabbitMqQueueOptionsBuilder.cs
+++ b/Rebus.RabbitMq/Config/RabbitMqQueueOptionsBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Rebus.Config
 {
@@ -26,11 +27,27 @@ namespace Rebus.Config
         }
 
         /// <summary>
-        /// Set auto delete
+        /// Set auto delete, when last consumer disconnects
         /// </summary>
         public RabbitMqQueueOptionsBuilder SetAutoDelete(bool autoDelete)
         {
             AutoDelete = autoDelete;
+            return this;
+        }
+
+        /// <summary>
+        /// Set queue time-to-live, the time before queue expires after last consumer disconnects, and is auto deleted
+        /// <see cref="https://www.rabbitmq.com/ttl.html#queue-ttl"/>
+        /// </summary>
+        /// <param name="ttlInMs">Time to live in milliseconds</param>
+        /// <returns></returns>
+        public RabbitMqQueueOptionsBuilder SetTtl(int ttlInMs)
+        {
+            if (ttlInMs < 1)
+            {
+                throw new ArgumentException("Time must be in milliseconds and greater than 0", nameof(ttlInMs));
+            }
+            Arguments.Add("x-expires", ttlInMs);
             return this;
         }
 
@@ -46,7 +63,7 @@ namespace Rebus.Config
         /// <summary>
         /// Add input queue arguments to the default settings
         /// </summary>
-        public RabbitMqQueueOptionsBuilder AddArgument(string key, string val)
+        public RabbitMqQueueOptionsBuilder AddArgument(string key, object val)
         {
             Arguments.Add(key, val);
             return this;

--- a/Rebus.RabbitMq/Config/RabbitMqQueueOptionsBuilder.cs
+++ b/Rebus.RabbitMq/Config/RabbitMqQueueOptionsBuilder.cs
@@ -37,7 +37,7 @@ namespace Rebus.Config
 
         /// <summary>
         /// Set queue time-to-live, the time before queue expires after last consumer disconnects, and is auto deleted
-        /// <see cref="https://www.rabbitmq.com/ttl.html#queue-ttl"/>
+        /// https://www.rabbitmq.com/ttl.html
         /// </summary>
         /// <param name="ttlInMs">Time to live in milliseconds</param>
         /// <returns></returns>

--- a/Rebus.RabbitMq/Config/RabbitMqQueueOptionsBuilder.cs
+++ b/Rebus.RabbitMq/Config/RabbitMqQueueOptionsBuilder.cs
@@ -28,26 +28,20 @@ namespace Rebus.Config
 
         /// <summary>
         /// Set auto delete, when last consumer disconnects
+        /// <param name="autoDelete">Whether queue should be deleted</param>
+        /// <param name="ttlInMs">Time to live (in milliseconds) after last subscriber disconnects</param>
         /// </summary>
-        public RabbitMqQueueOptionsBuilder SetAutoDelete(bool autoDelete)
+        public RabbitMqQueueOptionsBuilder SetAutoDelete(bool autoDelete, long ttlInMs = 0)
         {
-            AutoDelete = autoDelete;
-            return this;
-        }
-
-        /// <summary>
-        /// Set queue time-to-live, the time before queue expires after last consumer disconnects, and is auto deleted
-        /// https://www.rabbitmq.com/ttl.html
-        /// </summary>
-        /// <param name="ttlInMs">Time to live in milliseconds</param>
-        /// <returns></returns>
-        public RabbitMqQueueOptionsBuilder SetTtl(long ttlInMs)
-        {
-            if (ttlInMs < 1)
+            if (ttlInMs < 0)
             {
                 throw new ArgumentException("Time must be in milliseconds and greater than 0", nameof(ttlInMs));
             }
-            Arguments.Add("x-expires", ttlInMs);
+            else
+            {
+                Arguments.Add("x-expires", ttlInMs);
+            }
+            AutoDelete = autoDelete;
             return this;
         }
 

--- a/Rebus.RabbitMq/Config/RabbitMqQueueOptionsBuilder.cs
+++ b/Rebus.RabbitMq/Config/RabbitMqQueueOptionsBuilder.cs
@@ -41,7 +41,7 @@ namespace Rebus.Config
         /// </summary>
         /// <param name="ttlInMs">Time to live in milliseconds</param>
         /// <returns></returns>
-        public RabbitMqQueueOptionsBuilder SetTtl(int ttlInMs)
+        public RabbitMqQueueOptionsBuilder SetTtl(long ttlInMs)
         {
             if (ttlInMs < 1)
             {


### PR DESCRIPTION
Summary of changes:

- Fixed the AddArgument property of the RabbitMqQueueOptionsBuilder to allow passing object values in (simply setting all the arguments would have allowed this).
- Added additional configuration parameter that sets `x-expires` argument before calling queueDeclare.

I ran all unit tests before and after and saw no differences in success. Made sure to document the method and incorporate argument checking as well

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
