### PR TITLE
Include RabbitMQ UserId Header in TransportMessage

### DIFF
--- a/Rebus.RabbitMq/RabbitMq/RabbitMqTransport.cs
+++ b/Rebus.RabbitMq/RabbitMq/RabbitMqTransport.cs
@@ -426,6 +426,9 @@ namespace Rebus.RabbitMq
                 AddMessageId(headers, basicProperties, body);
             }
 
+            if (basicProperties.IsUserIdPresent())
+                headers[RabbitMqHeaders.UserId] = basicProperties.UserId;
+
             return new TransportMessage(headers, body);
         }
 


### PR DESCRIPTION
Fixes #44 

Preserve the UserId RabbitMq Property when creating the TransportMessage. 

---

Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, **I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase**.