### PR TITLE
suggested fix for "PRECONDITION_FAILED - invalid arg 'x-expires' for queue '...'…

### DIFF
--- a/Rebus.RabbitMq.Tests/RabbitMqCreateQueueTest.cs
+++ b/Rebus.RabbitMq.Tests/RabbitMqCreateQueueTest.cs
@@ -1,0 +1,82 @@
+﻿using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Config;
+using Rebus.Tests.Contracts;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rebus.RabbitMq.Tests
+{
+    [TestFixture]
+    public class RabbitMqCreateQueueTest : FixtureBase
+    {
+        readonly string _testQueue1 = TestConfig.GetName("test_queue_1");
+
+        protected override void SetUp()
+        {
+            RabbitMqTransportFactory.DeleteQueue(_testQueue1);
+        }
+
+        [Test]
+        public void Test_CreateQueue_WHEN_InputQueueOptions_AutoDelete_False_AND_TTL0_THEN_BusCanStart()
+        {
+            var activator = Using(new BuiltinHandlerActivator());
+            var configurer = Configure.With(activator)
+                  .Transport(t =>
+                  {
+                      t.UseRabbitMq(RabbitMqTransportFactory.ConnectionString, _testQueue1)
+                        .InputQueueOptions(o => o.SetAutoDelete(false))
+                        .AddClientProperties(new Dictionary<string, string> {
+                            { "description", "CreateQueue_With_AutoDelete test in RabbitMqCreateQueueTest.cs" }
+                        });
+                  });
+            var bus = configurer.Start();
+
+            Assert.IsTrue(bus.Advanced.Workers.Count > 0);
+        }
+
+
+        [Test]
+        public void Test_CreateQueue_WHEN_InputQueueOptions_AutoDelete_True_AND_TTL_Positive_THEN_BusCanStart()
+        {
+            var activator = Using(new BuiltinHandlerActivator());
+            var configurer = Configure.With(activator)
+                  .Transport(t =>
+                  {
+                      t.UseRabbitMq(RabbitMqTransportFactory.ConnectionString, _testQueue1)
+                        .InputQueueOptions(o => o.SetAutoDelete(true, 1))
+                        .AddClientProperties(new Dictionary<string, string> {
+                            { "description", "CreateQueue_With_AutoDelete test in RabbitMqCreateQueueTest.cs" }
+                        });
+                  });
+
+            var bus = configurer.Start();
+
+            Assert.IsTrue(bus.Advanced.Workers.Count > 0);
+        }
+
+        [Test]
+        public void Test_CreateQueue_WHEN_InputQueueOptions_AutoDelete_True_AND_TTL_0_THEN_ArgumentExceptionThrown()
+        {
+            var activator = Using(new BuiltinHandlerActivator());
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var configurer = Configure.With(activator)
+                    .Transport(t =>
+                    {
+                        t.UseRabbitMq(RabbitMqTransportFactory.ConnectionString, _testQueue1)
+                        .InputQueueOptions(o => o.SetAutoDelete(true, 0))
+                        .AddClientProperties(new Dictionary<string, string> {
+                            { "description", "CreateQueue_With_AutoDelete test in RabbitMqCreateQueueTest.cs" }
+                        });
+                    });
+            }
+            , "Time must be in milliseconds and greater than 0");
+        }
+    }
+}

--- a/Rebus.RabbitMq/Config/RabbitMqQueueOptionsBuilder.cs
+++ b/Rebus.RabbitMq/Config/RabbitMqQueueOptionsBuilder.cs
@@ -33,15 +33,14 @@ namespace Rebus.Config
         /// </summary>
         public RabbitMqQueueOptionsBuilder SetAutoDelete(bool autoDelete, long ttlInMs = 0)
         {
-            if (ttlInMs < 0)
-            {
-                throw new ArgumentException("Time must be in milliseconds and greater than 0", nameof(ttlInMs));
-            }
-            else
-            {
-                Arguments.Add("x-expires", ttlInMs);
-            }
             AutoDelete = autoDelete;
+
+            if (AutoDelete && ttlInMs <= 0)
+                throw new ArgumentException("Time must be in milliseconds and greater than 0", nameof(ttlInMs));
+
+            if (AutoDelete)
+                Arguments.Add("x-expires", ttlInMs);
+
             return this;
         }
 


### PR DESCRIPTION
Hi,

Sorry, if you get a couple of other pull requests. My Git-client put wrong email adress into the commit and I was trying to correct that... 

I get this error with the latest version of Rebus.RabbitMQ (5.1.0.0) from RabbitMq

**"PRECONDITION_FAILED - invalid arg 'x-expires' for queue '…' in vhost '/': {value_zero,0}", classId=50, methodId=10, cause="**

The error occurs when the bus is created using .InputQueueOptions() configurer, with SetAutoDelete(false). It seems that the config builder adds "x-expires" regardless of the auto-delete value, wich means "x-expires" has value 0 (the default of the ttlMs parameter) when auto-delete is false.

I suggest that "x-expires" is only included, if the autoDelete argument is true and the ttl is a positive number (exception otherwise, as before).

I was not sure how to fit proper unit tests for your project, but I have included some simple start up tests of the bus, that failed before this fix, and pass when the fix is included:
`Message: Rebus.Injection.ResolutionException : Could not resolve Rebus.Bus.IBus with decorator depth 0 - registrations: Rebus.Injection.Injectionist+Handler
  ----> Rebus.Exceptions.RebusApplicationException : Queue declaration for 'test_queue_1' failed
  ----> RabbitMQ.Client.Exceptions.OperationInterruptedException : The AMQP operation was interrupted: AMQP close-reason, initiated by Peer, code=406, text="PRECONDITION_FAILED - invalid arg 'x-expires' for queue 'test_queue_1' in vhost '/': {value_zero,0}", classId=50, methodId=10, cause=
`

Please let me know, if this is a correct solution, thank you! 

Best regards
Jarik

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
