### PR TITLE
restore broken "Automatically create input queue if it suddenly disappears" feature

### DIFF
--- a/Rebus.RabbitMq.Tests/RabbitMqReceiveSubscriptionTests.cs
+++ b/Rebus.RabbitMq.Tests/RabbitMqReceiveSubscriptionTests.cs
@@ -1,0 +1,58 @@
+﻿using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Config;
+using Rebus.Tests.Contracts;
+using Rebus.Tests.Contracts.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rebus.RabbitMq.Tests
+{
+    [TestFixture]
+    public class RabbitMqReceiveSubscriptionTests : FixtureBase
+    {
+        readonly string _publisherQueueName = TestConfig.GetName("publisher");
+        readonly string _subscriberQueueName = TestConfig.GetName("subscriber");
+
+        [Test]
+        public async Task Test_ReceieveOnSubscribe_WHEN_SubscriberQueueDeleted_THEN_ItRecreates_SubscirberQuere_AND_ReceivesPublishedData()
+        {
+            var message = "Test-Message-123";
+            var receivedEvent = new ManualResetEvent(false);
+            var publisher = GetBus("publisher");
+
+            var subscriber = GetBus("subscriber", async data =>
+            {
+                if (string.Equals(data, message))
+                    receivedEvent.Set();
+            });
+
+            await subscriber.Bus.Subscribe<string>();
+
+            RabbitMqTransportFactory.DeleteQueue(_subscriberQueueName);
+
+            await publisher.Bus.Publish(message);
+
+            receivedEvent.WaitOrDie(TimeSpan.FromSeconds(5));
+        }
+
+
+        BuiltinHandlerActivator GetBus(string queueName, Func<string, Task> handlerMethod = null)
+        {
+            var activator = Using(new BuiltinHandlerActivator());
+            activator?.Handle(handlerMethod);
+
+            Configure.With(activator).Transport(t =>
+            {
+                t.UseRabbitMq(RabbitMqTransportFactory.ConnectionString, queueName)
+                    .AddClientProperties(new Dictionary<string, string> { { "description", "Created for RabbitMqReceiveTests" } });
+            }).Start();
+
+            return activator;
+        }
+    }
+}

--- a/Rebus.RabbitMq.Tests/RabbitMqReceiveSubscriptionTests.cs
+++ b/Rebus.RabbitMq.Tests/RabbitMqReceiveSubscriptionTests.cs
@@ -15,17 +15,23 @@ namespace Rebus.RabbitMq.Tests
     [TestFixture]
     public class RabbitMqReceiveSubscriptionTests : FixtureBase
     {
-        readonly string _publisherQueueName = TestConfig.GetName("publisher");
-        readonly string _subscriberQueueName = TestConfig.GetName("subscriber");
+        readonly string _publisherQueueName = TestConfig.GetName("publisher-RabbitMqReceiveSubscriptionTests");
+        readonly string _subscriberQueueName = TestConfig.GetName("subscriber-RabbitMqReceiveSubscriptionTests");
+
+        protected override void SetUp()
+        {
+            RabbitMqTransportFactory.DeleteQueue(_publisherQueueName);
+            RabbitMqTransportFactory.DeleteQueue(_subscriberQueueName);
+        }
 
         [Test]
         public async Task Test_ReceieveOnSubscribe_WHEN_SubscriberQueueDeleted_THEN_ItRecreates_SubscirberQuere_AND_ReceivesPublishedData()
         {
             var message = "Test-Message-123";
             var receivedEvent = new ManualResetEvent(false);
-            var publisher = GetBus("publisher");
+            var publisher = GetBus(_publisherQueueName);
 
-            var subscriber = GetBus("subscriber", async data =>
+            var subscriber = GetBus(_subscriberQueueName, async data =>
             {
                 if (string.Equals(data, message))
                     receivedEvent.Set();

--- a/Rebus.RabbitMq/RabbitMq/RabbitMqTransport.cs
+++ b/Rebus.RabbitMq/RabbitMq/RabbitMqTransport.cs
@@ -328,6 +328,19 @@ namespace Rebus.RabbitMq
                 {
                     consumer = InitializeConsumer();
                 }
+                else
+                {
+                    try
+                    {
+                        // When a consumer is dequeued from the the "consumers" pool, it might be bound to a queue, which does not exist anymore,
+                        // eg. expired and deleted by RabittMQ server policy). In this case this calling QueueDeclarePassive will result in 
+                        // an OperationInterruptedException and "consumer.Model.IsOpen" will be set to false (this is handled later in the code by 
+                        // disposing this consumer). There is no need to handle this exception. The logic of InitializeConsumer() will make sure 
+                        // that the queue is recreated later based on assumption about how ReBus is handling null-result of ITransport.Receive().
+                        consumer?.Model.QueueDeclarePassive(Address);
+                    }
+                    catch { }
+                }
 
                 if (consumer == null)
                 {


### PR DESCRIPTION
It looks like the feature "Automatically create input queue if it suddenly disappears while the app is running " announced in release "5.0.0" has been broken in a later release, when the method EnsureConsumerInitialized() was refactored. 

Here is my suggestion for fixing this in RabbitMqTransport, based on "Model.QueueDeclarePassive" try-catch. In case of failure, the transport must recycle the "broken" (unbound) model and try to re-create subscriptions using existing logic.

Please advice, whether this way of queue-existence checking may have any negative impact on the performance or is it ok to have this way?

A unit test is included to illustrate the problem scenario and wanted behavior.

Best regards
/Jarik
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
