### PR TITLE
incorrect implementation of RabbitMqQueueOptionsBuilder.SetAutoDelete()

### DIFF
--- a/Rebus.RabbitMq.Tests/RabbitMqCreateQueueTest.cs
+++ b/Rebus.RabbitMq.Tests/RabbitMqCreateQueueTest.cs
@@ -14,69 +14,119 @@ namespace Rebus.RabbitMq.Tests
     [TestFixture]
     public class RabbitMqCreateQueueTest : FixtureBase
     {
-        readonly string _testQueue1 = TestConfig.GetName("test_queue_1");
-
-        protected override void SetUp()
-        {
-            RabbitMqTransportFactory.DeleteQueue(_testQueue1);
-        }
-
         [Test]
-        public void Test_CreateQueue_WHEN_InputQueueOptions_AutoDelete_False_AND_TTL0_THEN_BusCanStart()
+        public void Test_CreateQueue_WHEN_InputQueueOptions_AutoDelete_False_AND_TTL0_THEN_BusCanStart_()
         {
-            var activator = Using(new BuiltinHandlerActivator());
-            var configurer = Configure.With(activator)
-                  .Transport(t =>
-                  {
-                      t.UseRabbitMq(RabbitMqTransportFactory.ConnectionString, _testQueue1)
-                        .InputQueueOptions(o => o.SetAutoDelete(false))
-                        .AddClientProperties(new Dictionary<string, string> {
-                            { "description", "CreateQueue_With_AutoDelete test in RabbitMqCreateQueueTest.cs" }
-                        });
-                  });
-            var bus = configurer.Start();
-
-            Assert.IsTrue(bus.Advanced.Workers.Count > 0);
-        }
-
-
-        [Test]
-        public void Test_CreateQueue_WHEN_InputQueueOptions_AutoDelete_True_AND_TTL_Positive_THEN_BusCanStart()
-        {
-            var activator = Using(new BuiltinHandlerActivator());
-            var configurer = Configure.With(activator)
-                  .Transport(t =>
-                  {
-                      t.UseRabbitMq(RabbitMqTransportFactory.ConnectionString, _testQueue1)
-                        .InputQueueOptions(o => o.SetAutoDelete(true, 1))
-                        .AddClientProperties(new Dictionary<string, string> {
-                            { "description", "CreateQueue_With_AutoDelete test in RabbitMqCreateQueueTest.cs" }
-                        });
-                  });
-
-            var bus = configurer.Start();
-
-            Assert.IsTrue(bus.Advanced.Workers.Count > 0);
-        }
-
-        [Test]
-        public void Test_CreateQueue_WHEN_InputQueueOptions_AutoDelete_True_AND_TTL_0_THEN_ArgumentExceptionThrown()
-        {
-            var activator = Using(new BuiltinHandlerActivator());
-
-            Assert.Throws<ArgumentException>(() =>
+            using (var testScope = new QeueuNameTestScope())
             {
+                var activator = Using(new BuiltinHandlerActivator());
+                var configurer = Configure.With(activator)
+                      .Transport(t =>
+                      {
+                          t.UseRabbitMq(RabbitMqTransportFactory.ConnectionString, testScope.QeueuName)
+                            .InputQueueOptions(o => o.SetAutoDelete(false))
+                            .AddClientProperties(new Dictionary<string, string> {
+                            { "description", "CreateQueue_With_AutoDelete test in RabbitMqCreateQueueTest.cs" }
+                            });
+                      });
+
+                using (var bus = configurer.Start())
+                {
+                    Assert.IsTrue(bus.Advanced.Workers.Count > 0);
+                }
+
+                Thread.Sleep(5000);
+                Assert.IsTrue(RabbitMqTransportFactory.QueueExists(testScope.QeueuName));
+            }
+        }
+
+        [Test]
+        public void Test_CreateQueue_WHEN_InputQueueOptions_AutoDelete_True_THEN_BusCanStart()
+        {
+            using (var testScope = new QeueuNameTestScope())
+            {
+                var activator = Using(new BuiltinHandlerActivator());
+                var configurer = Configure.With(activator)
+                      .Transport(t =>
+                      {
+                          t.UseRabbitMq(RabbitMqTransportFactory.ConnectionString, testScope.QeueuName)
+                            .InputQueueOptions(o => o.SetAutoDelete(true))
+                            .AddClientProperties(new Dictionary<string, string> {
+                            { "description", "CreateQueue_With_AutoDelete test in RabbitMqCreateQueueTest.cs" }
+                            });
+                      });
+
+                using (var bus = configurer.Start())
+                {
+                    Assert.IsTrue(bus.Advanced.Workers.Count > 0);
+                }
+            }
+        }
+
+        [Test]
+        public void Test_CreateQueue_WHEN_InputQueueOptions_SetQueueTTL_0_THEN_ArgumentException()
+        {
+            using (var testScope = new QeueuNameTestScope())
+            {
+                var activator = Using(new BuiltinHandlerActivator());
+
+                Assert.Throws<ArgumentException>(() =>
+                {
+                    var configurer = Configure.With(activator)
+                        .Transport(t =>
+                        {
+                            t.UseRabbitMq(RabbitMqTransportFactory.ConnectionString, testScope.QeueuName)
+                            .InputQueueOptions(o => o.SetQueueTTL(0).SetDurable(false))
+                            .AddClientProperties(new Dictionary<string, string> {
+                            { "description", "CreateQueue_With_AutoDelete test in RabbitMqCreateQueueTest.cs" }
+                            });
+                        });
+                }
+                , "Time must be in milliseconds and greater than 0");
+            }
+        }
+
+        [Test]
+        public void Test_CreateQueue_WHEN_InputQueueOptions_SetQueueTTL_5000_THEN_QueueIsDeleted_WHEN_5000msAfterConnectionClosed()
+        {
+            using (var testScope = new QeueuNameTestScope())
+            {
+                var activator = Using(new BuiltinHandlerActivator());
+
                 var configurer = Configure.With(activator)
                     .Transport(t =>
                     {
-                        t.UseRabbitMq(RabbitMqTransportFactory.ConnectionString, _testQueue1)
-                        .InputQueueOptions(o => o.SetAutoDelete(true, 0))
+                        t.UseRabbitMq(RabbitMqTransportFactory.ConnectionString, testScope.QeueuName)
+                        .InputQueueOptions(o => o.SetQueueTTL(100))
                         .AddClientProperties(new Dictionary<string, string> {
                             { "description", "CreateQueue_With_AutoDelete test in RabbitMqCreateQueueTest.cs" }
                         });
                     });
+
+                using (var bus = configurer.Start())
+                {
+                    Assert.IsTrue(bus.Advanced.Workers.Count > 0);                    
+                }
+
+                Thread.Sleep(5000);
+                Assert.IsFalse(RabbitMqTransportFactory.QueueExists(testScope.QeueuName));
             }
-            , "Time must be in milliseconds and greater than 0");
         }
+        
+        class QeueuNameTestScope : IDisposable
+        {
+            public string QeueuName { get; }
+
+            public QeueuNameTestScope()
+            {
+                QeueuName = Guid.NewGuid().ToString();
+            }
+
+            public void Dispose()
+            {
+                RabbitMqTransportFactory.DeleteQueue(QeueuName);
+            }
+        }
+
     }
 }

--- a/Rebus.RabbitMq.Tests/RabbitMqTransportFactory.cs
+++ b/Rebus.RabbitMq.Tests/RabbitMqTransportFactory.cs
@@ -61,6 +61,24 @@ namespace Rebus.RabbitMq.Tests
             }
         }
 
+        public static bool QueueExists(string queueName)
+        {
+            var connectionFactory = new ConnectionFactory { Uri = new Uri(ConnectionString) };
+            using (var connection = connectionFactory.CreateConnection())
+            using (var model = connection.CreateModel())
+            {
+                try
+                {
+                    model.QueueDeclarePassive(queueName);
+                    return true;
+                }
+                catch (RabbitMQ.Client.Exceptions.OperationInterruptedException)
+                {
+                    return false;
+                }
+            }
+        }
+
         public static void DeleteExchange(string exchangeName)
         {
             var connectionFactory = new ConnectionFactory { Uri = new Uri(ConnectionString) };
@@ -109,9 +127,9 @@ namespace Rebus.RabbitMq.Tests
                 }
             }
         }
-        
+
         protected virtual RabbitMqTransport CreateRabbitMqTransport(string inputQueueAddress)
-        {   
+        {
             return new RabbitMqTransport(ConnectionString, inputQueueAddress, new ConsoleLoggerFactory(false));
         }
     }

--- a/Rebus.RabbitMq/Config/RabbitMqQueueOptionsBuilder.cs
+++ b/Rebus.RabbitMq/Config/RabbitMqQueueOptionsBuilder.cs
@@ -27,19 +27,43 @@ namespace Rebus.Config
         }
 
         /// <summary>
-        /// Set auto delete, when last consumer disconnects
+        /// Set auto-delete propery when declaring the queue
+        /// <param name="autoDelete">Whether queue should be deleted when the last consumer unsubscribes</param>
+        /// </summary>
+        public RabbitMqQueueOptionsBuilder SetAutoDelete(bool autoDelete)
+        {
+            AutoDelete = autoDelete;
+            return this;
+        }
+
+        /// <summary>
+        /// Configure for how long a queue can be unused before it is automatically deleted by setting x-expires argument
+        /// </summary>
+        /// <param name="ttlInMs">expiration period in milliseconds, </param>
+        /// <exception cref="ArgumentException">if the argumnet value is 0 or less</exception>
+        public RabbitMqQueueOptionsBuilder SetQueueTTL(long ttlInMs)
+        {
+            if (ttlInMs <= 0)
+                throw new ArgumentException("Time must be in milliseconds and greater than 0", nameof(ttlInMs));
+
+            Arguments.Add("x-expires", ttlInMs);
+
+            return this;
+        }
+
+
+        /// <summary>
+        /// Set auto delete, when last consumer disconnects and/or how long queue can stay unused until it is deleted as expired.
+        /// Zero or negative values of ttlInMs are ignored (no queue expiration).
         /// <param name="autoDelete">Whether queue should be deleted</param>
         /// <param name="ttlInMs">Time to live (in milliseconds) after last subscriber disconnects</param>
         /// </summary>
         public RabbitMqQueueOptionsBuilder SetAutoDelete(bool autoDelete, long ttlInMs = 0)
         {
-            AutoDelete = autoDelete;
+            SetAutoDelete(autoDelete);
 
-            if (AutoDelete && ttlInMs <= 0)
-                throw new ArgumentException("Time must be in milliseconds and greater than 0", nameof(ttlInMs));
-
-            if (AutoDelete)
-                Arguments.Add("x-expires", ttlInMs);
+            if (ttlInMs > 0)
+                SetQueueTTL(ttlInMs);
 
             return this;
         }


### PR DESCRIPTION
Corrected error in RabbitMqQueueOptionsBuilder.SetAutoDelete(): it was impossible to configure QueueTTL unless autoDelete is ON, and those are completely independent parameters in RMQ.

The original version cannot be used to setting queue TTL and *not* enabling autoDelete at the same time.  To workaround one had to disable auto-delete through SetAutoDelete() and set queue TTL as AddArgument("x-expires",TTL_MS).
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
