### PR TITLE
incorrect implementation of RabbitMqQueueOptionsBuilder.SetAutoDelete() and ClientConnectionName(string connectionName) to RabbitMqOptionsBuilder to propogate the connection_name property

### DIFF
--- a/Rebus.RabbitMq.Tests/RabbitMqCreateQueueTest.cs
+++ b/Rebus.RabbitMq.Tests/RabbitMqCreateQueueTest.cs
@@ -24,6 +24,7 @@ namespace Rebus.RabbitMq.Tests
                       {
                           t.UseRabbitMq(RabbitMqTransportFactory.ConnectionString, testScope.QeueuName)
                             .InputQueueOptions(o => o.SetAutoDelete(false))
+                            .ClientConnectionName("Test Client Connection Name")
                             .AddClientProperties(new Dictionary<string, string> {
                             { "description", "CreateQueue_With_AutoDelete test in RabbitMqCreateQueueTest.cs" }
                             });
@@ -31,7 +32,7 @@ namespace Rebus.RabbitMq.Tests
 
                 using (var bus = configurer.Start())
                 {
-                    Assert.IsTrue(bus.Advanced.Workers.Count > 0);
+                    Assert.IsTrue(bus.Advanced.Workers.Count > 0); Thread.Sleep(500000);
                 }
 
                 Thread.Sleep(5000);

--- a/Rebus.RabbitMq.Tests/RabbitMqCreateQueueTest.cs
+++ b/Rebus.RabbitMq.Tests/RabbitMqCreateQueueTest.cs
@@ -24,7 +24,6 @@ namespace Rebus.RabbitMq.Tests
                       {
                           t.UseRabbitMq(RabbitMqTransportFactory.ConnectionString, testScope.QeueuName)
                             .InputQueueOptions(o => o.SetAutoDelete(false))
-                            .ClientConnectionName("Test Client Connection Name")
                             .AddClientProperties(new Dictionary<string, string> {
                             { "description", "CreateQueue_With_AutoDelete test in RabbitMqCreateQueueTest.cs" }
                             });
@@ -32,7 +31,7 @@ namespace Rebus.RabbitMq.Tests
 
                 using (var bus = configurer.Start())
                 {
-                    Assert.IsTrue(bus.Advanced.Workers.Count > 0); Thread.Sleep(500000);
+                    Assert.IsTrue(bus.Advanced.Workers.Count > 0);
                 }
 
                 Thread.Sleep(5000);

--- a/Rebus.RabbitMq.Tests/RabbitMqTransportFactory.cs
+++ b/Rebus.RabbitMq.Tests/RabbitMqTransportFactory.cs
@@ -61,6 +61,24 @@ namespace Rebus.RabbitMq.Tests
             }
         }
 
+        public static bool QueueExists(string queueName)
+        {
+            var connectionFactory = new ConnectionFactory { Uri = new Uri(ConnectionString) };
+            using (var connection = connectionFactory.CreateConnection())
+            using (var model = connection.CreateModel())
+            {
+                try
+                {
+                    model.QueueDeclarePassive(queueName);
+                    return true;
+                }
+                catch (RabbitMQ.Client.Exceptions.OperationInterruptedException)
+                {
+                    return false;
+                }
+            }
+        }
+
         public static void DeleteExchange(string exchangeName)
         {
             var connectionFactory = new ConnectionFactory { Uri = new Uri(ConnectionString) };
@@ -109,9 +127,9 @@ namespace Rebus.RabbitMq.Tests
                 }
             }
         }
-        
+
         protected virtual RabbitMqTransport CreateRabbitMqTransport(string inputQueueAddress)
-        {   
+        {
             return new RabbitMqTransport(ConnectionString, inputQueueAddress, new ConsoleLoggerFactory(false));
         }
     }

--- a/Rebus.RabbitMq/Config/RabbitMqOptionsBuilder.cs
+++ b/Rebus.RabbitMq/Config/RabbitMqOptionsBuilder.cs
@@ -273,7 +273,7 @@ namespace Rebus.Config
         }
 
         /// This is temporary decorator-fix, until Rebus is upgraded to a version 6+ of RabbitMQ.Client wich has new signature:
-        /// IConnection CreateConnection(IList<AmqpTcpEndpoint> endpoints, string clientProvidedName) 
+        /// IConnection CreateConnection(IList AmqpTcpEndpoint endpoints, string clientProvidedName) 
         /// so it is more correct to provide the name of client connection in ConnectionManager.GetConnection() method, when connections are created.
         class ConnectionFactoryClientNameDecorator : IConnectionFactory
         {

--- a/Rebus.RabbitMq/Config/RabbitMqOptionsBuilder.cs
+++ b/Rebus.RabbitMq/Config/RabbitMqOptionsBuilder.cs
@@ -272,13 +272,9 @@ namespace Rebus.Config
             transport.SetExchangeOptions(ExchangeOptions);
         }
 
-        /// <summary>
         /// This is temporary decorator-fix, until Rebus is upgraded to a version 6+ of RabbitMQ.Client wich has new signature:
-        /// 
-        ///       IConnection CreateConnection(IList<AmqpTcpEndpoint> endpoints, string clientProvidedName) 
-        /// 
+        /// IConnection CreateConnection(IList<AmqpTcpEndpoint> endpoints, string clientProvidedName) 
         /// so it is more correct to provide the name of client connection in ConnectionManager.GetConnection() method, when connections are created.
-        /// </summary>
         class ConnectionFactoryClientNameDecorator : IConnectionFactory
         {
             private readonly IConnectionFactory _decoratedFactory;

--- a/Rebus.RabbitMq/Config/RabbitMqOptionsBuilder.cs
+++ b/Rebus.RabbitMq/Config/RabbitMqOptionsBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using RabbitMQ.Client;
 using Rebus.RabbitMq;
 
@@ -147,7 +148,7 @@ namespace Rebus.Config
 
             return this;
         }
-        
+
         /// <summary>
         /// Configure input exchanges manually. 
         /// </summary>
@@ -177,7 +178,7 @@ namespace Rebus.Config
             SslSettings = sslSettings;
             return this;
         }
-        
+
         /// <summary>
         /// Enable the publisher confirms protocol.
         /// This method is intended to use when publishers cannot afford message loss.
@@ -187,7 +188,17 @@ namespace Rebus.Config
             PublisherConfirms = value;
             return this;
         }
-        
+
+        /// <summary>
+        /// Set the connection_name property (user-friendly non-unique client connection name) of RabbitMQ connection, which is 
+        /// shown in the connections overview list and in the client properites of a connection.         
+        /// </summary>
+        /// <exception cref="InvalidOperationException">expcetion is thrown if another connection factory customizer is in use</exception>
+        public RabbitMqOptionsBuilder ClientConnectionName(string connectionName)
+        {
+            return CustomizeConnectionFactory(factory => new ConnectionFactoryClientNameDecorator(factory, connectionName));
+        }
+
         internal bool? DeclareExchanges { get; private set; }
         internal bool? DeclareInputQueue { get; private set; }
         internal bool? BindInputQueue { get; private set; }
@@ -197,7 +208,7 @@ namespace Rebus.Config
         internal string TopicExchangeName { get; private set; }
 
         internal int? MaxNumberOfMessagesToPrefetch { get; private set; }
-        
+
         internal SslSettings SslSettings { get; private set; }
 
         internal RabbitMqCallbackOptionsBuilder CallbackOptionsBuilder { get; } = new RabbitMqCallbackOptionsBuilder();
@@ -251,14 +262,137 @@ namespace Rebus.Config
             {
                 transport.SetCallbackOptions(CallbackOptionsBuilder);
             }
-            
+
             if (PublisherConfirms.HasValue)
             {
                 transport.EnablePublisherConfirms(PublisherConfirms.Value);
             }
-            
+
             transport.SetInputQueueOptions(QueueOptions);
             transport.SetExchangeOptions(ExchangeOptions);
+        }
+
+        /// <summary>
+        /// This is temporary decorator-fix, until Rebus is upgraded to a version 6+ of RabbitMQ.Client wich has new signature:
+        /// 
+        ///       IConnection CreateConnection(IList<AmqpTcpEndpoint> endpoints, string clientProvidedName) 
+        /// 
+        /// so it is more correct to provide the name of client connection in ConnectionManager.GetConnection() method, when connections are created.
+        /// </summary>
+        class ConnectionFactoryClientNameDecorator : IConnectionFactory
+        {
+            private readonly IConnectionFactory _decoratedFactory;
+            private readonly string _clientProvidedName;
+
+            public IDictionary<string, object> ClientProperties
+            {
+                get { return _decoratedFactory.ClientProperties; }
+                set { _decoratedFactory.ClientProperties = value; }
+            }
+
+            public TimeSpan ContinuationTimeout
+            {
+                get { return _decoratedFactory.ContinuationTimeout; }
+                set { _decoratedFactory.ContinuationTimeout = value; }
+            }
+
+            public TimeSpan HandshakeContinuationTimeout
+            {
+                get { return _decoratedFactory.HandshakeContinuationTimeout; }
+                set { _decoratedFactory.HandshakeContinuationTimeout = value; }
+            }
+
+            public string Password
+            {
+                get { return _decoratedFactory.Password; }
+                set { _decoratedFactory.Password = value; }
+            }
+
+            public ushort RequestedChannelMax
+            {
+                get { return _decoratedFactory.RequestedChannelMax; }
+                set { _decoratedFactory.RequestedChannelMax = value; }
+            }
+
+            public uint RequestedFrameMax
+            {
+                get { return _decoratedFactory.RequestedFrameMax; }
+                set { _decoratedFactory.RequestedFrameMax = value; }
+            }
+
+            public ushort RequestedHeartbeat
+            {
+                get { return _decoratedFactory.RequestedHeartbeat; }
+                set { _decoratedFactory.RequestedHeartbeat = value; }
+            }
+
+            public TaskScheduler TaskScheduler
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                get { return _decoratedFactory.TaskScheduler; }
+                set { _decoratedFactory.TaskScheduler = value; }
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
+
+            public Uri Uri
+            {
+                get { return _decoratedFactory.Uri; }
+                set { _decoratedFactory.Uri = value; }
+            }
+
+            public bool UseBackgroundThreadsForIO
+            {
+                get { return _decoratedFactory.UseBackgroundThreadsForIO; }
+                set { _decoratedFactory.UseBackgroundThreadsForIO = value; }
+            }
+
+            public string UserName
+            {
+                get { return _decoratedFactory.UserName; }
+                set { _decoratedFactory.UserName = value; }
+            }
+
+            public string VirtualHost
+            {
+                get { return _decoratedFactory.VirtualHost; }
+                set { _decoratedFactory.VirtualHost = value; }
+            }
+
+            public ConnectionFactoryClientNameDecorator(IConnectionFactory originalFacotry, string clientProvidedName)
+            {
+                _decoratedFactory = originalFacotry;
+                _clientProvidedName = clientProvidedName;
+            }
+
+            public AuthMechanismFactory AuthMechanismFactory(IList<string> mechanismNames)
+            {
+                return _decoratedFactory.AuthMechanismFactory(mechanismNames);
+            }
+
+            public IConnection CreateConnection(IList<AmqpTcpEndpoint> endpoints)
+            {
+                return (_decoratedFactory as RabbitMQ.Client.ConnectionFactory).CreateConnection(new DefaultEndpointResolver(endpoints), _clientProvidedName);
+            }
+
+            public IConnection CreateConnection()
+            {
+                return _decoratedFactory.CreateConnection(_clientProvidedName);
+            }
+
+            public IConnection CreateConnection(string clientProvidedName)
+            {
+                return _decoratedFactory.CreateConnection(clientProvidedName);
+            }
+
+            public IConnection CreateConnection(IList<string> hostnames)
+            {
+                return _decoratedFactory.CreateConnection(hostnames, _clientProvidedName);
+            }
+
+            public IConnection CreateConnection(IList<string> hostnames, string clientProvidedName)
+            {
+                return _decoratedFactory.CreateConnection(hostnames, clientProvidedName);
+            }
         }
     }
 }

--- a/Rebus.RabbitMq/Config/RabbitMqQueueOptionsBuilder.cs
+++ b/Rebus.RabbitMq/Config/RabbitMqQueueOptionsBuilder.cs
@@ -27,19 +27,43 @@ namespace Rebus.Config
         }
 
         /// <summary>
-        /// Set auto delete, when last consumer disconnects
+        /// Set auto-delete propery when declaring the queue
+        /// <param name="autoDelete">Whether queue should be deleted when the last consumer unsubscribes</param>
+        /// </summary>
+        public RabbitMqQueueOptionsBuilder SetAutoDelete(bool autoDelete)
+        {
+            AutoDelete = autoDelete;
+            return this;
+        }
+
+        /// <summary>
+        /// Configure for how long a queue can be unused before it is automatically deleted by setting x-expires argument
+        /// </summary>
+        /// <param name="ttlInMs">expiration period in milliseconds, </param>
+        /// <exception cref="ArgumentException">if the argumnet value is 0 or less</exception>
+        public RabbitMqQueueOptionsBuilder SetQueueTTL(long ttlInMs)
+        {
+            if (ttlInMs <= 0)
+                throw new ArgumentException("Time must be in milliseconds and greater than 0", nameof(ttlInMs));
+
+            Arguments.Add("x-expires", ttlInMs);
+
+            return this;
+        }
+
+
+        /// <summary>
+        /// Set auto delete, when last consumer disconnects and/or how long queue can stay unused until it is deleted as expired.
+        /// Zero or negative values of ttlInMs are ignored (no queue expiration).
         /// <param name="autoDelete">Whether queue should be deleted</param>
         /// <param name="ttlInMs">Time to live (in milliseconds) after last subscriber disconnects</param>
         /// </summary>
         public RabbitMqQueueOptionsBuilder SetAutoDelete(bool autoDelete, long ttlInMs = 0)
         {
-            AutoDelete = autoDelete;
+            SetAutoDelete(autoDelete);
 
-            if (AutoDelete && ttlInMs <= 0)
-                throw new ArgumentException("Time must be in milliseconds and greater than 0", nameof(ttlInMs));
-
-            if (AutoDelete)
-                Arguments.Add("x-expires", ttlInMs);
+            if (ttlInMs > 0)
+                SetQueueTTL(ttlInMs);
 
             return this;
         }


### PR DESCRIPTION
Corrected error in RabbitMqQueueOptionsBuilder.SetAutoDelete(): it was impossible to configure QueueTTL unless autoDelete is ON, and those are completely independent parameters in RMQ.

The original version cannot be used to setting queue TTL and not enabling autoDelete at the same time. To workaround one had to disable auto-delete through SetAutoDelete() and set queue TTL as AddArgument("x-expires",TTL_MS).

I belive, it will fix [issue 55](https://github.com/rebus-org/Rebus.RabbitMq/issues/55)
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
