### PR TITLE
In RabbitMqTransport.Receive call QueueDeclarePassive only if declare input queue is true

### DIFF
--- a/Rebus.RabbitMq.Tests/RabbitMqTransportFactory.cs
+++ b/Rebus.RabbitMq.Tests/RabbitMqTransportFactory.cs
@@ -56,6 +56,17 @@ namespace Rebus.RabbitMq.Tests
             _queuesToDelete.Clear();
         }
 
+        public static void CreateQueue(string queueName)
+        {
+            var connectionFactory = new ConnectionFactory { Uri = new Uri(ConnectionString) };
+
+            using (var connection = connectionFactory.CreateConnection())
+            using (var model = connection.CreateModel())
+            {
+                model.QueueDeclare(queueName, true, false, false);
+            }
+        }
+
         public static void DeleteQueue(string queueName)
         {
             var connectionFactory = new ConnectionFactory { Uri = new Uri(ConnectionString) };

--- a/Rebus.RabbitMq/RabbitMq/RabbitMqTransport.cs
+++ b/Rebus.RabbitMq/RabbitMq/RabbitMqTransport.cs
@@ -344,7 +344,11 @@ namespace Rebus.RabbitMq
                         // an OperationInterruptedException and "consumer.Model.IsOpen" will be set to false (this is handled later in the code by 
                         // disposing this consumer). There is no need to handle this exception. The logic of InitializeConsumer() will make sure 
                         // that the queue is recreated later based on assumption about how ReBus is handling null-result of ITransport.Receive().
-                        consumer?.Model.QueueDeclarePassive(Address);
+                        // Applied this logic to recreate the queue only if the transport is configure initially to create the queue if it doesnt exists.
+                        if (_declareInputQueue)
+                        {
+                            consumer?.Model.QueueDeclarePassive(Address);
+                        }
                     }
                     catch { }
                 }


### PR DESCRIPTION
In an environment where the Rabbit server configurations are managed manually and where it is important to maintain the performance KPIs, it has a negative impact when checking the existence of the queue which maintains the state of the channel in running.

This situation is not desired as it impacts the performance of the RabbitMQ server and gives information incorrect on the push status of the messages detected in the server monitoring console.

In this context we need to submit the queue existence check to a configuration parameter. At the moment we propose to activate the check only if you ask the library to create the queue.

Best regards.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
