### PR TITLE
Possibly fix system staying dead if RabbitMQ was temporary unavailable

### DIFF
--- a/Rebus.RabbitMq/Internals/CustomQueueingConsumer.cs
+++ b/Rebus.RabbitMq/Internals/CustomQueueingConsumer.cs
@@ -38,6 +38,7 @@ namespace Rebus.Internals
         public void Dispose()
         {
             Model.SafeDrop();
+            Queue.Writer.TryComplete();
         }
     }
 }

--- a/Rebus.RabbitMq/RabbitMq/RabbitMqTransport.cs
+++ b/Rebus.RabbitMq/RabbitMq/RabbitMqTransport.cs
@@ -416,7 +416,7 @@ namespace Rebus.RabbitMq
                 catch (ChannelClosedException)
                 {
                     _log.Error("Channel was closed, removing");
-                    _consumer.Dispose();
+                    _consumer?.Dispose();
                     _consumer = null;
                     return null;
                 }

--- a/Rebus.RabbitMq/RabbitMq/RabbitMqTransport.cs
+++ b/Rebus.RabbitMq/RabbitMq/RabbitMqTransport.cs
@@ -413,6 +413,13 @@ namespace Rebus.RabbitMq
                     result = await _consumer.Queue.Reader.ReadAsync(readTimeout.Token);
                     _log.Debug("Read message from queue");
                 }
+                catch (ChannelClosedException)
+                {
+                    _log.Error("Channel was closed, removing");
+                    _consumer.Dispose();
+                    _consumer = null;
+                    return null;
+                }
                 catch (OperationCanceledException)
                 {
                     _log.Debug("Reading from queue was cancelled");


### PR DESCRIPTION
Fixes #88

~~This does instead cause some null references immediately after, as some of the workers apparently try to access the consumer between it being disposed and set to null. I'm not entirely sure to fix that without causing even more issue. The NullReferenceException issues are also temporary, and the normal retrying will resolve it.~~
Fixed

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
