### PR TITLE
Change default SslProtocols version in SslSettings to match current recommendations

### DIFF
--- a/Rebus.RabbitMq/RabbitMq/SslSettings.cs
+++ b/Rebus.RabbitMq/RabbitMq/SslSettings.cs
@@ -11,7 +11,7 @@ public class SslSettings
     /// <summary>
     /// Constructs an SslSettings 
     /// </summary>
-    public SslSettings(bool enabled, string serverName, string certificatePath = "", string certPassphrase = "", SslProtocols version = SslProtocols.Tls, SslPolicyErrors acceptablePolicyErrors = SslPolicyErrors.None)
+    public SslSettings(bool enabled, string serverName, string certificatePath = "", string certPassphrase = "", SslProtocols version = SslProtocols.None, SslPolicyErrors acceptablePolicyErrors = SslPolicyErrors.None)
     {
         Enabled = enabled;
         ServerName = serverName;


### PR DESCRIPTION
This PR fixes the issue mentioned in #106 consisting of an outdated default `SslProtocols` version.
It has been replaced by `SslProtocols.None` which is the recommended approach per the documentation.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
