### PR TITLE
Created configuration to set a consumer tag

### DIFF
--- a/Rebus.RabbitMq/Config/RabbitMqOptionsBuilder.cs
+++ b/Rebus.RabbitMq/Config/RabbitMqOptionsBuilder.cs
@@ -242,6 +242,15 @@ public class RabbitMqOptionsBuilder
         return this;
     }
 
+    /// <summary>
+    /// Sets the consumer tag. The actual tag will include a random string to guarantee uniqueness. 
+    /// </summary>
+    public RabbitMqOptionsBuilder SetConsumerTag(string consumerTag)
+    {
+        ConsumerTag = consumerTag;
+        return this;
+    }
+
     internal bool? DeclareExchanges { get; private set; }
     internal bool? DeclareInputQueue { get; private set; }
     internal bool? BindInputQueue { get; private set; }
@@ -250,6 +259,8 @@ public class RabbitMqOptionsBuilder
 
     internal string DirectExchangeName { get; private set; }
     internal string TopicExchangeName { get; private set; }
+    
+    internal string ConsumerTag { get; private set; }
 
     internal int? MaxNumberOfMessagesToPrefetch { get; private set; }
 
@@ -322,6 +333,7 @@ public class RabbitMqOptionsBuilder
         transport.SetDefaultQueueOptions(DefaultQueueOptionsBuilder);
         transport.SetExchangeOptions(ExchangeOptions);
         transport.SetMaxWriterPoolSize(MaxWriterPoolSize);
+        transport.SetConsumerTag(ConsumerTag);
     }
 
     /// This is temporary decorator-fix, until Rebus is upgraded to a version 6+ of RabbitMQ.Client wich has new signature:

--- a/Rebus.RabbitMq/RabbitMq/RabbitMqTransport.cs
+++ b/Rebus.RabbitMq/RabbitMq/RabbitMqTransport.cs
@@ -61,6 +61,8 @@ public class RabbitMqTransport : AbstractRebusTransport, IDisposable, IInitializ
     bool _publisherConfirmsEnabled = true;
     TimeSpan _publisherConfirmsTimeout;
 
+    string _consumerTag = null;
+
     string _directExchangeName = RabbitMqOptionsBuilder.DefaultDirectExchangeName;
     string _topicExchangeName = RabbitMqOptionsBuilder.DefaultTopicExchangeName;
 
@@ -245,6 +247,11 @@ public class RabbitMqTransport : AbstractRebusTransport, IDisposable, IInitializ
     public void SetMaxWriterPoolSize(int poolSize)
     {
         _writerPool.SetMaxEntries(poolSize);
+    }
+
+    public void SetConsumerTag(string consumerTag)
+    {
+        _consumerTag = consumerTag;
     }
 
     /// <summary>
@@ -678,7 +685,9 @@ public class RabbitMqTransport : AbstractRebusTransport, IDisposable, IInitializ
 
             var consumer = new CustomQueueingConsumer(model);
 
-            model.BasicConsume(queue: Address, autoAck: false, consumer: consumer);
+            model.BasicConsume(queue: Address, autoAck: false, consumer: consumer, 
+                consumerTag: _consumerTag != null ? $"{_consumerTag}-{Path.GetRandomFileName().Replace(".", "")}" : ""
+                );
 
             _log.Info("Successfully initialized consumer for {queueName}", Address);
 


### PR DESCRIPTION
The actual consumer tag is completed by appending a random string to preserve uniqueness. If no option is set, then an empty string is passed, which instructs Rabbit to create a consumer tag.

As discussed in #112. 

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
