### PR TITLE
Configure SslOptions for endpoints using amqps scheme

### DIFF
--- a/Rebus.RabbitMq/Internals/ConnectionManager.cs
+++ b/Rebus.RabbitMq/Internals/ConnectionManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -126,7 +126,8 @@ class ConnectionManager : IDisposable
             {
                 try
                 {
-                    return new AmqpTcpEndpoint(new Uri(uriString));
+                    var uri = new Uri(uriString);
+                    return new AmqpTcpEndpoint(uri, uri.Scheme == "amqps" ? new SslOption(uri.Host, enabled: true) : null);
                 }
                 catch (Exception exception)
                 {


### PR DESCRIPTION
This enables TLS support on simple `UseRabbitMq` override.

Fixes #120.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
