### PR TITLE
fix potential race conditions in ModelObjectPool

### DIFF
--- a/Rebus.RabbitMq.Tests/Examples/CheckMaximumDegreeOfParallelism.cs
+++ b/Rebus.RabbitMq.Tests/Examples/CheckMaximumDegreeOfParallelism.cs
@@ -50,7 +50,8 @@ public class CheckMaximumDegreeOfParallelism : FixtureBase
             .Transport(t =>
             {
                 t.UseRabbitMq(RabbitMqTransportFactory.ConnectionString, queueName)
-                    .Prefetch(maxNumberOfMessagesToPrefetch: 3 * maxParallelism);
+                    .Prefetch(maxNumberOfMessagesToPrefetch: 3 * maxParallelism)
+                    .SetPublisherConfirms(false);
             })
             .Options(o =>
             {


### PR DESCRIPTION
This PR fixes #123

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
