### PR TITLE
Feature: adding support for RabbitMQ consistent hash exchange type

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Build and run your RabbitMQ with management console, with the following shell co
 docker run -d --hostname my-rabbit --name some-rabbit -p 5672:5672 -p 8080:15672 rabbitmq:3-management
 ```
 
+In the docker desktop, exec the following shell command:
+```
+rabbitmq-plugins enable rabbitmq_consistent_hash_exchange
+```
+
 From your web brower, navigate to the RabbitMQ management console,
 
 ```
@@ -30,5 +35,10 @@ password: guest
 In Visual Studio 2017, run All Tests form the menus: Tests -> Run -> All Tests. While test are running, switch back to the management console, and watch:
 
 ![](https://github.com/jonmat/Rebus.RabbitMq/blob/master/rabbit-mgmt-console.png)
+
+## Supported out of the box RabbitMQ exchange types
+* Direct
+* Topic
+* [Consistent Hash](https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbitmq_consistent_hash_exchange/README.md): requires enabling the corresponding plugin by running the command `rabbitmq-plugins enable rabbitmq_consistent_hash_exchange`
 
 

--- a/Rebus.RabbitMq.Tests/RabbitMqConsistentHashExchangeTest.cs
+++ b/Rebus.RabbitMq.Tests/RabbitMqConsistentHashExchangeTest.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Config;
+using Rebus.Tests.Contracts;
+using Rebus.Tests.Contracts.Extensions;
+// ReSharper disable ArgumentsStyleNamedExpression
+
+#pragma warning disable 1998
+
+namespace Rebus.RabbitMq.Tests
+{
+    [TestFixture]
+    public class RabbitMqConsistentHashExchangeTest : FixtureBase
+    {
+        [Test]
+        public async Task WorksWithConsistentHashExchange()
+        {
+            const string connectionString = RabbitMqTransportFactory.ConnectionString;
+
+            const string exchangeName = "RebusTestConsistentHashExchange";
+            const string queueNamePattern = "consistent-hash-xchange-bound-queue";
+
+            using (var activator = new BuiltinHandlerActivator())
+            {
+                Configure.With(activator)
+                    .Transport(t =>
+                    {
+                        t
+                            .UseRabbitMq(connectionString, queueNamePattern)
+                            // Create 2 Queues & bind to the same consistent hash exchange:
+                            .UseConsistentHashExchange(2, exchangeName);
+                    })
+                    .Start();
+
+                // Send N messages to spread semi-evenly among queues
+                for (int i = 1; i <= 10; i++)
+                {
+                    await activator.Bus.Advanced.Routing.Send($"{i}@{exchangeName}", $"test_{i}", new Dictionary<string, string>());
+                }
+            }
+
+            // Assert the exchange and all queues were created:
+            Assert.That(RabbitMqTransportFactory.ExchangeExists(exchangeName), Is.True);
+            Assert.That(RabbitMqTransportFactory.QueueExists(queueNamePattern + "_1"), Is.True);
+            Assert.That(RabbitMqTransportFactory.QueueExists(queueNamePattern + "_2"), Is.True);
+        }
+    }
+}

--- a/Rebus.RabbitMq.Tests/RabbitMqTransportFactory.cs
+++ b/Rebus.RabbitMq.Tests/RabbitMqTransportFactory.cs
@@ -109,5 +109,24 @@ namespace Rebus.RabbitMq.Tests
                 }
             }
         }
+
+        public static bool QueueExists(string name)
+        {
+            var connectionFactory = new ConnectionFactory { Uri = new Uri(ConnectionString) };
+
+            using (var connection = connectionFactory.CreateConnection())
+            using (var model = connection.CreateModel())
+            {
+                try
+                {
+                    model.QueueDeclarePassive(name);
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+        }    
     }
 }

--- a/Rebus.RabbitMq/Config/RabbitMqOptionsBuilder.cs
+++ b/Rebus.RabbitMq/Config/RabbitMqOptionsBuilder.cs
@@ -247,6 +247,12 @@ namespace Rebus.Config
                 transport.SetCallbackOptions(CallbackOptionsBuilder);
             }
 
+            if (ConsistentHashExchangeName != null)
+            {
+                transport.SetConsistentHashExchangeName(ConsistentHashExchangeName);
+                transport.SetNumberOfConsistentHashQueues(NumberOfConsistentHashQueues);
+            }
+
             transport.SetInputQueueOptions(QueueOptions);
         }
     }

--- a/Rebus.RabbitMq/RabbitMq/RabbitMqTransport.cs
+++ b/Rebus.RabbitMq/RabbitMq/RabbitMqTransport.cs
@@ -214,9 +214,18 @@ namespace Rebus.RabbitMq
                 using (var model = connection.CreateModel())
                 {
                     CreateExchanges(model);
-                    for (int i = 0; i < _numberOfConsistentHashQueues; ++i)
+                    for (int i = 1; i <= _numberOfConsistentHashQueues; ++i)
                     {
-                        CreateQueue($"{Address}_{i}");
+                        var address = $"{Address}_{i}";
+                        if (_declareInputQueue)
+                        {
+                            DeclareQueue(address, model);
+                        }
+
+                        if (_bindInputQueue)
+                        {
+                            model.QueueBind(address, _consistentHashExchangeName, i.ToString());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
# Why Consistent Hashing?
A RabbitMQ queue is running on at most 1 CPU core, feature of Erlang Beam VM architecture.
To achieve horizontal scalability, it is advised to have multiple queues.

One variant of such topology is declaring a [Consistent Hash Exchange] (https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbitmq_consistent_hash_exchange/README.md):
- one exchange of type `x-consistent-hash`, multiple `N` queues, all bound to the same consistent hash exchange;
- the message is published to one above exchange but then sent exactly once by the RabbitMQ to a queue `i` in `[0 .. N)` based on the hashed routing key;
- The topology preserves message order as FIFO within each message partition `[0 .. N)`
