### PR TITLE
Fix Rebus.RabbitMQ not noticing if queues has been created after the initial check failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,9 @@
 ## 10.0.0
 * Update RabbitMQ client to v7 - thanks [zlepper]
 
+## 10.0.1
+* Fix Rebus.RabbitMQ not noticing if queues has been created after the initial check failed - thanks [zlepper]
+
 ---
 
 [bzuu]: https://github.com/bzuu

--- a/Rebus.RabbitMq.Tests/RabbitMqQueueExistsTest.cs
+++ b/Rebus.RabbitMq.Tests/RabbitMqQueueExistsTest.cs
@@ -33,4 +33,20 @@ public class RabbitMqQueueExistsTest : FixtureBase
 
         Assert.ThrowsAsync<RebusApplicationException>(() => _bus.Advanced.Routing.Send(queueName, "hej"));
     }
+
+    [Test]
+    public async Task DiscoversThatQueuesHaveBeenCreated()
+    {
+        var queueName = TestConfig.GetName("non-existing-queue");
+        await RabbitMqTransportFactory.DeleteQueue(queueName);
+        
+        Assert.ThrowsAsync<RebusApplicationException>(() => _bus.Advanced.Routing.Send(queueName, "hej"));
+
+        await RabbitMqTransportFactory.CreateQueue(queueName);
+        
+        Assert.That(async () =>
+        {
+            await _bus.Advanced.Routing.Send(queueName, "hej");
+        }, Throws.Nothing);
+    }
 }


### PR DESCRIPTION
Easy workaround is the  simply restart the process, however it's easier if this is not a problem in the first place. 

This was introduced by the upgrade to v7 of the client library.


---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
