### PR TITLE
Feature: provide a way to use existing rabbitmq connection factories …

### DIFF
--- a/Rebus.RabbitMq/Config/RabbitMqConfigurationExtensions.cs
+++ b/Rebus.RabbitMq/Config/RabbitMqConfigurationExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using RabbitMQ.Client;
 using Rebus.Injection;
 using Rebus.Internals;
 using Rebus.Logging;
@@ -7,6 +6,8 @@ using Rebus.RabbitMq;
 using Rebus.Retry;
 using Rebus.Subscriptions;
 using Rebus.Transport;
+using System;
+using System.Collections.Generic;
 // ReSharper disable ExpressionIsAlwaysNull
 // ReSharper disable ArgumentsStyleNamedExpression
 
@@ -37,6 +38,16 @@ public static class RabbitMqConfigurationExtensions
         if (endpoints == null) throw new ArgumentNullException(nameof(endpoints));
 
         return BuildInternal(configurer, true, (context, options) => new RabbitMqTransport(endpoints, null, context.Get<IRebusLoggerFactory>(), customizer: options.ConnectionFactoryCustomizer));
+    }
+
+    /// <summary>
+    /// Configures Rebus to use RabbitMQ to move messages around
+    /// </summary>
+    public static RabbitMqOptionsBuilder UseRabbitMq(this StandardConfigurer<ITransport> configurer, List<AmqpTcpEndpoint> endpoints, string inputQueueName, IConnectionFactory? factory, IConnection? connection)
+    {
+        if (inputQueueName == null) throw new ArgumentNullException(nameof(inputQueueName));
+        return BuildInternal(configurer, false, (context, options) => new RabbitMqTransport(endpoints, inputQueueName, factory, connection, context.Get<IRebusLoggerFactory>()));
+
     }
 
     /// <summary>

--- a/Rebus.RabbitMq/RabbitMq/RabbitMqTransport.cs
+++ b/Rebus.RabbitMq/RabbitMq/RabbitMqTransport.cs
@@ -100,6 +100,21 @@ public class RabbitMqTransport : AbstractRebusTransport, IAsyncDisposable, IDisp
     }
 
     /// <summary>
+    /// Constructs the RabbitMQ transport with multiple amqp tcp endpoints. They should be also used in the connection factory.
+    ///  A Connection factory and an existing connection must also be provided
+    /// </summary>
+    public RabbitMqTransport(List<AmqpTcpEndpoint> endpoints, string inputQueueAddress, IConnectionFactory? factory, IConnection? connection,
+        IRebusLoggerFactory rebusLoggerFactory, int maxMessagesToPrefetch = 50)
+        : this(rebusLoggerFactory, maxMessagesToPrefetch, inputQueueAddress)
+    {
+        if (endpoints == null) throw new ArgumentNullException(nameof(endpoints));
+        if (factory == null) throw new ArgumentNullException(nameof(factory));
+        if (connection == null) throw new ArgumentNullException(nameof(connection));
+
+        _connectionManager = new ConnectionManager(rebusLoggerFactory, endpoints, inputQueueAddress, factory, connection);
+    }
+
+    /// <summary>
     /// Constructs the RabbitMQ transport with multiple connection endpoints. They will be tried in random order until working one is found
     ///  Credentials will be extracted from the connectionString of the first provided endpoint
     /// </summary>


### PR DESCRIPTION
…and connections to enable oauth2 workflows and such

This enables workflows like in this rabbitmq example:
https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/main/projects/Test/OAuth2/TestOAuth2.cs

especially since some projects might already have a need for custom logic interfacing with the IConnection.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
