### PR TITLE
Ensure client connection name is set on the original IConnectionFactory

### DIFF
--- a/Rebus.RabbitMq/Config/RabbitMqOptionsBuilder.cs
+++ b/Rebus.RabbitMq/Config/RabbitMqOptionsBuilder.cs
@@ -436,6 +436,8 @@ public class RabbitMqOptionsBuilder
         {
             _decoratedFactory = originalFacotry;
             _clientProvidedName = clientProvidedName;
+
+            _decoratedFactory.ClientProvidedName = clientProvidedName;
         }
 
         public IAuthMechanismFactory AuthMechanismFactory(IEnumerable<string> mechanismNames)


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
